### PR TITLE
Make it possible to use env variable from the local environement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ module.exports = {
       ROOT_URL: 'app.com',
       MONGO_URL: 'mongodb://localhost/meteor'
     },
+    variablesFromLocalEnv: { //optional
+      'AWS_KEY',
+      'AWS_SECRET',
+    },
     logs: { //optional
       driver: 'syslog',
       opts: {

--- a/lib/modules/meteor/index.js
+++ b/lib/modules/meteor/index.js
@@ -123,6 +123,11 @@ export function envconfig(api) {
   const list = nodemiral.taskList('Configuring  Meteor Environment Variables');
 
   var env = _.clone(config.env);
+  var variablesFromLocalEnv = config.variablesFromLocalEnv || [];
+  for (var k in variablesFromLocalEnv) {
+    var envVarName = variablesFromLocalEnv[k];
+    env[envVarName] = process.env[envVarName];
+  }
   env.METEOR_SETTINGS = JSON.stringify(api.getSettings());
   // sending PORT to the docker container is useless.
   // It'll run on PORT 80 and we can't override it


### PR DESCRIPTION
If an array of strings is specified in the config under `variablesFromLocalEnv`, they will be loaded form the local environment.
For instance in my config I can have

``` javascript
variablesFromLocalEnv = [
  'AWS_KEY',
  'AWS_SECRET'
]
```

So that those variables get passed to the build without appearing in config file directly
