### PR TITLE
--server-only build

### DIFF
--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -40,6 +40,10 @@ function buildMeteorApp(appPath, buildLocaltion, buildOptions, callback) {
     args.push(JSON.stringify(buildOptions.mobileSettings));
   }
 
+  if(buildOptions.serverOnly) {
+    args.push('--server-only');
+  }
+
   var isWin = /^win/.test(process.platform);
   if(isWin) {
     // Sometimes cmd.exe not available in the path


### PR DESCRIPTION
On meteor 1.3 adding --server-only in the build command will skip building native ios/android apps but will deploy web.cordova directory, enabling hot code push for cordova.

MDG info related 
https://forums.meteor.com/t/mupx-cordova-build/20745/7
https://forums.meteor.com/t/mupx-cordova-build/20745/2

Issue related
https://github.com/arunoda/meteor-up/issues/697
https://github.com/arunoda/meteor-up/issues/742
https://github.com/arunoda/meteor-up/issues/764
https://github.com/arunoda/meteor-up/issues/981
https://github.com/arunoda/meteor-up/issues/1005
