### PR TITLE
mup reads log key instead of logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ module.exports = {
       ROOT_URL: 'app.com',
       MONGO_URL: 'mongodb://localhost/meteor'
     },
-    logs: { //optional
+    log: { //optional
       driver: 'syslog',
       opts: {
-        url:'udp://syslogserverurl.com:1234'
+        "syslog-address":'udp://syslogserverurl.com:1234'
       }
     }
     dockerImage: 'madushan1000/meteord-test', //optional


### PR DESCRIPTION
- Example in the readme didn't work for me i found from source code that mup reads from log field shown [here](https://github.com/kadirahq/meteor-up/blob/master/src/modules/meteor/index.js#L105).
- Syslog driver in docker doesn't know any opts as url, i spent some time finding that out i wanted to change readme so others won't spend their time on this :)
