### PR TITLE
Fixed silent fail with use of ~ homedir shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-polyfill": "6.6.1",
     "bluebird": "3.x.x",
     "debug": "2.x.x",
+    "expand-home-dir": "0.0.3",
     "nodemiral": "1.x.x",
     "shelljs": "0.5.x",
     "silent-npm-registry-client": "2.x.x",

--- a/src/mup-api.js
+++ b/src/mup-api.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import nodemiral from 'nodemiral';
+import expandHomeDir from 'expand-home-dir';
 
 export default class MupAPI {
   constructor(base, args) {
@@ -102,7 +103,7 @@ export default class MupAPI {
       }
 
       if (info.pem) {
-        auth.pem = fs.readFileSync(path.resolve(info.pem), 'utf8');
+        auth.pem = fs.readFileSync(path.resolve(expandHomeDir(info.pem)), 'utf8');
       } else if (info.password) {
         auth.password = info.password;
       } else if (sshAgent && fs.existsSync(sshAgent)) {


### PR DESCRIPTION
- adds in new package `expand-home-dir` (this may not be welcome)
- simply traverses the `servers.pem` string and expands `~` into the full homedir path, if present, via function exposed by package
- previously `path.resolve()` could not handle the `~` shortcut and would cause the SSH connection to (silently) fail in the deploy and setup commands
- works with both `servers.pem` strings containing `~` and absolute paths
- fixes #189 
