### PR TITLE
Add the optional (undocumented) port option to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ module.exports = {
   meteor: {
     name: 'app',
     path: '../app',
+    port: 000, // Optional. Useful when deploying multiple instances
     volumes: { //optional, lets you add docker volumes
       "/host/path": "/container/path", //passed as '-v /host/path:/container/path' to the docker run command
       "/second/host/path": "/second/container/path"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module.exports = {
   meteor: {
     name: 'app',
     path: '../app',
-    port: 000, // Optional. Useful when deploying multiple instances
+    // port: 000, Optional. Useful when deploying multiple instances
     volumes: { //optional, lets you add docker volumes
       "/host/path": "/container/path", //passed as '-v /host/path:/container/path' to the docker run command
       "/second/host/path": "/second/container/path"

--- a/README.md
+++ b/README.md
@@ -262,6 +262,16 @@ We need to have two separate Meteor Up projects. For that, create two directorie
 
 In the staging `mup.js`, add a field called `appName` with the value `staging`. You can add any name you prefer instead of `staging`. Since we are running our staging app on port 8000, add an environment variable called `PORT` with the value 8000.
 
+You might also have to tell docker to use this custom port like this :
+
+```js
+meteor: {
+ ...
+ port: 8000
+ ...
+}
+```
+
 Now setup both projects and deploy as you need.
 
 ### Changing `appName`


### PR DESCRIPTION
Added the optional port option to the docker meteor block. Because if we are deploying multiple instances or want to deploy on a different port for some reason, setting only the environment variable as described in the Readme won't work. Docker will still start on port `80`. But adding this option (Which is already available but undocumented) will fix the issue. :smile: 
