### PR TITLE
deployment tests fails becase of lack of curl

### DIFF
--- a/src/modules/docker/assets/docker-setup.sh
+++ b/src/modules/docker/assets/docker-setup.sh
@@ -18,7 +18,7 @@ if [ ! "$hasDocker" ]; then
 
   # Required to update system
   sudo apt-get update
-  sudo apt-get -y install wget lxc iptables
+  sudo apt-get -y install wget lxc iptables curl
 
   # Install docker
   wget -qO- https://get.docker.com/ | sudo sh


### PR DESCRIPTION
Dependency on curl tool for deployment tests is not resolved. 
It cause deployment tests fail because of lack of this tool.
