### PR TITLE
Add {series: true} to stop issue with deploying to multiple servers.

### DIFF
--- a/src/modules/meteor/index.js
+++ b/src/modules/meteor/index.js
@@ -132,7 +132,7 @@ export function push(api) {
       });
 
       const sessions = api.getSessions([ 'meteor' ]);
-      return runTaskList(list, sessions);
+      return runTaskList(list, sessions, {series: true});
     });
 }
 
@@ -162,7 +162,7 @@ export function envconfig(api) {
     }
   });
   const sessions = api.getSessions([ 'meteor' ]);
-  return runTaskList(list, sessions);
+  return runTaskList(list, sessions, {series: true});
 }
 
 export function start(api) {


### PR DESCRIPTION
There must be a race condition when deploying in parallel. I didn't find the root cause / race condition, but this at least solves the issue of deploying to multiple servers.

Fixes #122 & #281 & #232.
