### PR TITLE
look for settings.json if !serverOnly

### DIFF
--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -44,7 +44,7 @@ function buildMeteorApp(appPath, buildOptions, callback) {
     args.push('--server-only');
   } else if(!buildOptions.mobileSettings) {
     args.push('--mobile-settings');
-    args.push(appPath + 'settings.json');
+    args.push(appPath + '/settings.json');
   }
 
   var isWin = /^win/.test(process.platform);

--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -42,6 +42,9 @@ function buildMeteorApp(appPath, buildOptions, callback) {
 
   if(buildOptions.serverOnly) {
     args.push('--server-only');
+  } else if(!buildOptions.mobileSettings) {
+    args.push('--mobile-settings');
+    args.push(appPath + 'settings.json');
   }
 
   var isWin = /^win/.test(process.platform);


### PR DESCRIPTION
I've found that mobileSettings variable fails with `Error: ENOENT: no such file or directory, open '"{ public : { } }"'`. Looking into the problem I realized that meteor --mobile-settings argument accepted only file path (maybe starting with 1.4).

Thus I propose the following default settings.json solution.
