### PR TITLE
Build with mobile application parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ module.exports = {
       debug: true,
       cleanAfterBuild: true, // default
       buildLocation: '/my/build/folder', // defaults to /tmp/<uuid>
-      mobileSettings: {
-        yourMobileSetting: "setting value"
-      }
+      
+      //set serverOnly: false if want to build mobile apps
+      mobileSettings: false, // get mobileSettings from settings.json file in app root (--mobile-settings settings.json) 
+      server: 'http://app.com', // your app url for mobile app access (--server http://app.com)
+      allowIncompatibleUpdates: true, //adds --allow-incompatible-updates key to build command
     },
     env: {
       ROOT_URL: 'app.com',

--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -51,8 +51,8 @@ function buildMeteorApp(appPath, buildOptions, callback) {
     args.push(buildOptions.server);
   }
 
-  if (buildOptions.allowIncompatibleUpdates) {
-    args.push('--allow-incompatible-updates');
+  if (buildOptions.allowIncompatibleUpdate) {
+    args.push('--allow-incompatible-update');
   }
 
   var isWin = /^win/.test(process.platform);

--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -44,7 +44,7 @@ function buildMeteorApp(appPath, buildOptions, callback) {
     args.push('--server-only');
   } else if(!buildOptions.mobileSettings) {
     args.push('--mobile-settings');
-    args.push(appPath + 'settings.json');
+    args.push(appPath + '/settings.json');
   }
 
   var isWin = /^win/.test(process.platform);

--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -42,6 +42,9 @@ function buildMeteorApp(appPath, buildOptions, callback) {
 
   if(buildOptions.serverOnly) {
     args.push('--server-only');
+  } else if(!buildOptions.mobileSettings) {
+    args.push('--mobile-settings');
+    args.push(appPath + 'settings.json');
   }
 
   var isWin = /^win/.test(process.platform);

--- a/src/modules/meteor/build.js
+++ b/src/modules/meteor/build.js
@@ -27,8 +27,7 @@ function buildMeteorApp(appPath, buildOptions, callback) {
   var executable = buildOptions.executable || 'meteor';
   var args = [
     "build", "--directory", buildOptions.buildLocation,
-    "--architecture", "os.linux.x86_64",
-    "--server", "http://localhost:3000"
+    "--architecture", "os.linux.x86_64"
   ];
 
   if(buildOptions.debug) {
@@ -45,6 +44,15 @@ function buildMeteorApp(appPath, buildOptions, callback) {
   } else if(!buildOptions.mobileSettings) {
     args.push('--mobile-settings');
     args.push(appPath + '/settings.json');
+  }
+
+  if(buildOptions.server) {
+    args.push('--server');
+    args.push(buildOptions.server);
+  }
+
+  if (buildOptions.allowIncompatibleUpdates) {
+    args.push('--allow-incompatible-updates');
   }
 
   var isWin = /^win/.test(process.platform);


### PR DESCRIPTION
As far as I see, current configuration does not concern building mup along with mobile applications. If I'm not right, please show me what's the correct configuration to do that.

My PR adds these parameters allowing to make app builds along with deploy. This is very handy if you don't want HCP with production applications. 
