### PR TITLE
Update README.md: remove redundant command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ This version of Meteor Up is powered by [Docker](http://www.docker.com/) and it 
 ### Creating a Meteor Up Project
     cd my-app-folder
     mkdir .deploy
-    cd .deploy
     mup init
 
 This will create two files in your Meteor Up project directory:


### PR DESCRIPTION
removed line which states `cd .deploy`
`mup init` should be run in project root folder in order to generate `mup.js` and `settings.json`
