### PR TITLE
Allow cached deploy without rebuilding Meteor bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ module.exports = {
       debug: true,
       cleanAfterBuild: true, // default
       buildLocation: '/my/build/folder', // defaults to /tmp/<uuid>
+      deployCachedBuild: false, // allows re-use of previous build if buildLocation given, defaults to false
       mobileSettings: {
         yourMobileSetting: "setting value"
       }

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ program
   .parse(process.argv);
 
 function argAction(arg, subarg) {
+
   let moduleArg = arg;
   let command = subarg;
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import program from 'commander';
 
 let settingsPath;
 let configPath;
+let forceRebuild = false;
 const args = process.argv.slice(2);
 
 program
@@ -12,10 +13,11 @@ program
   .action(argAction)
   .option('--settings <filePath>', 'Meteor settings file', setSettingsPath)
   .option('--config <filePath>', 'mup.js config file', setConfigPath)
+  .option('--rebuild', 'Force app rebuild')
   .parse(process.argv);
 
 function argAction(arg, subarg) {
-
+  debugger;
   let moduleArg = arg;
   let command = subarg;
 
@@ -51,9 +53,14 @@ function argAction(arg, subarg) {
     args.splice(0, 2);
   }
 
+  if(program.rebuild) {
+    forceRebuild = true;
+    args.splice(0, 2);
+  }
+
   checkUpdates().then(() => {
     const base = process.cwd();
-    const api = new MupAPI(base, args, configPath, settingsPath);
+    const api = new MupAPI(base, args, configPath, settingsPath, forceRebuild);
     module[command](api);
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ program
   .parse(process.argv);
 
 function argAction(arg, subarg) {
-  debugger;
   let moduleArg = arg;
   let command = subarg;
 

--- a/src/modules/meteor/index.js
+++ b/src/modules/meteor/index.js
@@ -101,7 +101,7 @@ export function push(api) {
   var bundlePath = path.resolve(buildOptions.buildLocation, 'bundle.tar.gz');
   const appPath = path.resolve(api.getBasePath(), config.path);
 
-  if (buildOptions.deployCachedBuild && fs.existsSync(bundlePath)) {
+  if (!api.isForceRebuild() && buildOptions.deployCachedBuild && fs.existsSync(bundlePath)) {
     console.log(`Using Cached App Bundle at ${bundlePath}`);
     return postBuild(api, config, bundlePath);
   } else {

--- a/src/mup-api.js
+++ b/src/mup-api.js
@@ -3,7 +3,7 @@ import path from 'path';
 import nodemiral from 'nodemiral';
 
 export default class MupAPI {
-  constructor(base, args, configPath, settingsPath) {
+  constructor(base, args, configPath, settingsPath, forceRebuild) {
     this.base = base;
     this.args = args;
     this.config = null;
@@ -11,6 +11,7 @@ export default class MupAPI {
     this.sessions = null;
     this.configPath = configPath;
     this.settingsPath = settingsPath;
+    this.forceRebuild = forceRebuild;
   }
 
   getArgs() {
@@ -68,6 +69,10 @@ export default class MupAPI {
     const api = Object.create(this);
     api.sessions = this._pickSessions(modules);
     return api;
+  }
+
+  isForceRebuild() {
+    return this.forceRebuild;
   }
 
   _pickSessions(modules = []) {


### PR DESCRIPTION
This PR allows mup to deploy a bundle that is already built. It's extremely useful for deploying to multiple app servers without having to rebuild the bundle for each one.

I've added an option in the Meteor config under `buildOptions`:

``` js
buildOptions: {
  buildLocation: '/tmp/some-build-name',
  deployCachedBuild: true,
},
```

If `deployCachedBuild` is set to `true` and `buildLocation` is set to something, then it will use an existing bundle.

This addresses #336 and is a good first step for #305 