### PR TITLE
Changed default Docker image to abernix/meteord:base

### DIFF
--- a/src/modules/default/template/mup.js.sample
+++ b/src/modules/default/template/mup.js.sample
@@ -2,7 +2,7 @@ module.exports = {
   servers: {
     one: {
       host: '1.2.3.4',
-      username: 'root'
+      username: 'root',
       // pem:
       // password:
       // or leave blank for authenticate from ssh-agent
@@ -13,18 +13,18 @@ module.exports = {
     name: 'app',
     path: '../app',
     servers: {
-      one: {}
+      one: {},
     },
     buildOptions: {
       serverOnly: true,
     },
     env: {
       ROOT_URL: 'app.com',
-      MONGO_URL: 'mongodb://localhost/meteor'
+      MONGO_URL: 'mongodb://localhost/meteor',
     },
 
-    //dockerImage: 'kadirahq/meteord'
-    deployCheckWaitTime: 60
+    dockerImage: 'abernix/meteord:base',
+    deployCheckWaitTime: 60,
   },
 
   mongo: {


### PR DESCRIPTION
Since most people are probably using Meteor 1.4.x by now, it makes sense IMO to just change the default docker image to `abernix/meteord:base` which supports Meteor 1.4. Out of the box, mup fails with Meteor 1.4.

(also added trailing commas throughout the JS file, because a lot of people get hung up on trivial errors when uncommenting lines and forgetting to add the commas)