### PR TITLE
Updated meteor validator to include buildLocation

### DIFF
--- a/src/validate/meteor.js
+++ b/src/validate/meteor.js
@@ -19,6 +19,7 @@ const schema = joi.object().keys({
     serverOnly: joi.bool(),
     debug: joi.bool(),
     cleanAfterBuild: joi.bool(),
+    buildLocation: joi.bool(),
     mobileSettings: joi.object(),
     server: joi.string().uri(),
     allowIncompatibleUpdates: joi.boolean(),


### PR DESCRIPTION
Buildlocation was not included in the validator and throws an error when you include it in the mup.js file.