### PR TITLE
Disconnect container network interface

### DIFF
--- a/src/modules/meteor/assets/meteor-stop.sh
+++ b/src/modules/meteor/assets/meteor-stop.sh
@@ -4,5 +4,5 @@ APPNAME=<%= appName %>
 
 sudo docker rm -f $APPNAME || :
 sudo docker rm -f $APPNAME-frontend || :
-sudo docker network disconnect -f $APPNAME || :
-sudo docker network disconnect -f $APPNAME-frontend || :
+sudo docker network disconnect bridge -f $APPNAME || :
+sudo docker network disconnect bridge -f $APPNAME-frontend || :

--- a/src/modules/meteor/assets/meteor-stop.sh
+++ b/src/modules/meteor/assets/meteor-stop.sh
@@ -4,3 +4,5 @@ APPNAME=<%= appName %>
 
 sudo docker rm -f $APPNAME || :
 sudo docker rm -f $APPNAME-frontend || :
+sudo docker network disconnect -f $APPNAME || :
+sudo docker network disconnect -f $APPNAME-frontend || :

--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -13,18 +13,19 @@ docker rm -f $APPNAME
 
 # Remove container network if still exists
 docker network disconnect bridge -f $APPNAME
+<% for(var network in docker.networks) { %>
+docker network disconnect <%=  docker.networks[network] %> -f $APPNAME
+
+<% } %>
 
 # Remove frontend container if exists
 docker rm -f $APPNAME-frontend
+docker network disconnect bridge -f $APPNAME-frontend
 echo "Removed $APPNAME-frontend"
 
-# Remove container network if still exists
-docker network disconnect bridge -f $APPNAME-frontend
 
 # Remove let's encrypt containers if exists
 docker rm -f $APPNAME-nginx-letsencrypt
-
-# Remove container network if still exists
 docker network disconnect bridge -f $APPNAME-nginx-letsencrypt
 echo "Removed $APPNAME-nginx-letsencrypt"
 

--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -18,11 +18,18 @@ docker network disconnect bridge -f $APPNAME
 docker rm -f $APPNAME-frontend
 echo "Removed $APPNAME-frontend"
 
+# Remove container network if still exists
+docker network disconnect bridge -f $APPNAME-frontend
+
 # Remove let's encrypt containers if exists
 docker rm -f $APPNAME-nginx-letsencrypt
+
+# Remove container network if still exists
+docker network disconnect bridge -f $APPNAME-nginx-letsencrypt
 echo "Removed $APPNAME-nginx-letsencrypt"
 
 docker rm -f $APPNAME-nginx-proxy
+docker network disconnect bridge -f $APPNAME-nginx-proxy
 echo "Removed $APPNAME-nginx-proxy"
 
 # We don't need to fail the deployment because of a docker hub downtime

--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -11,6 +11,9 @@ BIND=<%= bind %>
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
 
+# Remove container network if still exists
+docker network disconnect bridge -f $APPNAME
+
 # Remove frontend container if exists
 docker rm -f $APPNAME-frontend
 echo "Removed $APPNAME-frontend"


### PR DESCRIPTION
EDIT: Bugfix for [#478 comment](https://github.com/zodern/meteor-up/issues/478#issuecomment-284467495)
Sometimes deploy fails due to docker not removing the container network interface.
This will force the docker to disconnect the container interface.

