### PR TITLE
fix reverting to previous working version

### DIFF
--- a/src/modules/meteor/assets/meteor-deploy-check.sh
+++ b/src/modules/meteor/assets/meteor-deploy-check.sh
@@ -9,6 +9,7 @@ cd $APP_PATH
 revert_app (){
   docker logs --tail=50 $APPNAME 1>&2
   if [ -d last ]; then
+    sudo mv current buggy
     sudo mv last current
     sudo bash $START_SCRIPT > /dev/null 2>&1
 

--- a/src/modules/meteor/assets/meteor-deploy-check.sh
+++ b/src/modules/meteor/assets/meteor-deploy-check.sh
@@ -9,7 +9,7 @@ cd $APP_PATH
 revert_app (){
   docker logs --tail=50 $APPNAME 1>&2
   if [ -d last ]; then
-    sudo mv current buggy
+    sudo rm -fr current
     sudo mv last current
     sudo bash $START_SCRIPT > /dev/null 2>&1
 


### PR DESCRIPTION
the mv command simply moves the last directory into the current directory instead of renaming it.
we need to first rename current into "buggy" and then last into current.
perhaps we should also remove any old "buggy" directory