### PR TITLE
Fix issue with ZSH

### DIFF
--- a/src/plugins/meteor/assets/meteor-deploy-check.sh
+++ b/src/plugins/meteor/assets/meteor-deploy-check.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 APPNAME=<%= appName %>
 APP_PATH=/opt/$APPNAME
 IMAGE=mup-<%= appName %>

--- a/src/plugins/meteor/assets/meteor-deploy-check.sh
+++ b/src/plugins/meteor/assets/meteor-deploy-check.sh
@@ -48,7 +48,7 @@ while [[ true ]]; do
     <% if (host) { %> --header "HOST:$HOST" <% } %>  \
     && exit 0 
 
-  if [ "$elaspsed" == "$DEPLOY_CHECK_WAIT_TIME" ]; then
+  if [ "$elaspsed" "==" "$DEPLOY_CHECK_WAIT_TIME" ]; then
     revert_app
     exit 1
   fi


### PR DESCRIPTION
Ref: #448, #515

It seems that in  zsh, `==` behaves differently then in bash when inside `[..]`

This is because zsh uses `=` to expand the full path to the executable, which is why the error message rightly was ` zsh:31: = not found`

It looks like there are a couple ways around this. Surrounding the operators in quotes is only one way, so please let me know if you would prefer another approach!