### PR TITLE
Add meteor.ssl.upload boolean to validation

### DIFF
--- a/src/validate/meteor.js
+++ b/src/validate/meteor.js
@@ -68,7 +68,8 @@ const schema = joi.object().keys({
         .label('autogenerate'),
       crt: joi.string().trim(),
       key: joi.string().trim(),
-      port: joi.number()
+      port: joi.number(),
+      upload: joi.boolean()
     })
     .and('crt', 'key')
     .without('autogenerate', ['crt', 'key'])


### PR DESCRIPTION
Addresses [issue 546](https://github.com/zodern/meteor-up/issues/546), that using the `meteor.ssl.upload` flag gives validation warnings when running `mup deploy`