### PR TITLE
684 | Map port 80 from host to frontend container, and remove bind from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ module.exports = {
       // are using Meteor 1.3 or older
       image: 'abernix/meteord:base' , // (optional)
       imagePort: 80, // (optional, default: 80)
+      // lets you bind the docker container for the application
+      // image to a specific network interface (optional)
+      bind: '127.0.0.1',
 
       // lets you add/overwrite any parameter on
       // the docker run command (optional)
@@ -119,9 +122,6 @@ module.exports = {
       // (optional) Only used if using your own ssl certificates.
       // Default is "meteorhacks/mup-frontend-server"
       imageFrontendServer: 'meteorhacks/mup-frontend-server',
-      // lets you bind the docker container to a
-      // specific network interface (optional)
-      bind: '127.0.0.1',
       // lets you add network connections to perform after run
       // (runs docker network connect <net name> for each network listed here)
       networks: [

--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -123,11 +123,11 @@ EOT
     set -e
     docker run \
       -d \
+      -p 80:80 -p <%= sslConfig.port %>:443 \
       --restart=always \
       --volume=/opt/$APPNAME/config/bundle.crt:/bundle.crt \
       --volume=/opt/$APPNAME/config/private.key:/private.key \
       --link=$APPNAME:backend \
-      --publish=$BIND:<%= sslConfig.port %>:443 \
       --name=$APPNAME-frontend \
       <%= docker.imageFrontendServer %> /start.sh
   <% } %>


### PR DESCRIPTION
Even when SSL autogeneration is disabled. This makes the configuration for the frontend closer between SSL autogeneration enabled/disabled alternatives.

Resolves #684 and #685.