### PR TITLE
Add Proxy buffer configs. Meteor apps like Reaction etc. need it

### DIFF
--- a/src/modules/proxy/assets/templates/start.sh
+++ b/src/modules/proxy/assets/templates/start.sh
@@ -23,6 +23,12 @@ docker pull jwilder/nginx-proxy
 set -e
 echo "Pulled jwilder/nginx-proxy and jrcs/letsencrypt-nginx-proxy-companion"
 
+sudo cat <<EOT > /opt/$APPNAME/config/vhost.d/default
+proxy_buffer_size          128k;
+proxy_buffers              4 256k;
+proxy_busy_buffers_size    256k;;
+EOT
+
 <% if(typeof clientUploadLimit === 'number') { %>
 # This updates nginx for all vhosts
 sudo cat <<EOT > /opt/$APPNAME/config/nginx-default.conf
@@ -57,4 +63,3 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   jrcs/letsencrypt-nginx-proxy-companion
 echo "Ran jrcs/letsencrypt-nginx-proxy-companion"
-

--- a/src/modules/proxy/assets/templates/start.sh
+++ b/src/modules/proxy/assets/templates/start.sh
@@ -26,7 +26,7 @@ echo "Pulled jwilder/nginx-proxy and jrcs/letsencrypt-nginx-proxy-companion"
 sudo cat <<EOT > /opt/$APPNAME/config/vhost.d/default
 proxy_buffer_size          128k;
 proxy_buffers              4 256k;
-proxy_busy_buffers_size    256k;;
+proxy_busy_buffers_size    256k;
 EOT
 
 <% if(typeof clientUploadLimit === 'number') { %>


### PR DESCRIPTION
There is a problem with deployment apps like Reaction with a reverse proxy (I think similar ones have this problem too). After deployment there is an error 

> upstream sent too big header while reading response header from upstream

in mup-nginx-proxy container. Adding 

    proxy_buffer_size          128k;
    proxy_buffers              4 256k;
    proxy_busy_buffers_size    256k;

fixed that. So I added it to start.sh script. I'm sure it will be helpful for those who trying to use mup for Reaction commerce deployment.