### PR TITLE
Add oplog support for MongoDB

### DIFF
--- a/src/plugins/default/template/mup.js.sample
+++ b/src/plugins/default/template/mup.js.sample
@@ -27,7 +27,8 @@ module.exports = {
       // TODO: Change to your app's url
       // If you are using ssl, it needs to start with https://
       ROOT_URL: 'http://app.com',
-      MONGO_URL: 'mongodb://localhost/meteor',
+      MONGO_URL: 'mongodb://mongodb/meteor',
+      MONGO_OPLOG_URL: 'mongodb://mongodb/local',
     },
 
     // ssl: { // (optional)

--- a/src/plugins/mongo/assets/mongo-start.sh
+++ b/src/plugins/mongo/assets/mongo-start.sh
@@ -26,3 +26,10 @@ sudo docker run \
   --volume=/opt/mongodb/mongodb.conf:/mongodb.conf \
   --name=mongodb \
   mongo:$MONGO_VERSION mongod -f /mongodb.conf
+
+sleep 3
+
+echo "Creating replica set"
+
+sudo docker exec mongodb mongo --eval \
+  'rs.initiate({_id: "meteor", members: [{_id: 0, host: "127.0.0.1:27017"}]});'

--- a/src/plugins/mongo/assets/mongodb.conf
+++ b/src/plugins/mongo/assets/mongodb.conf
@@ -1,1 +1,2 @@
 dbpath=/data/db
+replSet=meteor


### PR DESCRIPTION
I put together a solution to #21 following @poltak's [post](https://github.com/zodern/meteor-up/issues/21#issuecomment-238032995).  Change summary:

* Setup replica set when starting MongoDB (after 3-second delay)
* Add `replSet` to MongoDB configuration file
* Change sample configuration to set `MONGO_OPLOG_URL`

Of course, this is only relevant to users who are using mup to deploy Mongo.  But the changes should only affect such users.  Also, for such users, the change to MongoDB configuration doesn't require any change on the user's behalf.  (I don't think it hurts to create a replica set and not use any of its features.)  But it enables users to be able to specify `MONGO_OPLOG_URL` in their `mup.js`, and get immediate oplog support.

I've tested this on two of my own servers and it works well.