### PR TITLE
Make bundle portable

### DIFF
--- a/src/plugins/meteor/build.js
+++ b/src/plugins/meteor/build.js
@@ -127,6 +127,7 @@ export function archiveApp(buildLocation, api, cb) {
     file: bundlePath,
     onwarn(message, data) { console.log(message, data); },
     cwd: buildLocation,
+    portable: true,
     gzip: {
       level: 9
     }


### PR DESCRIPTION
When deploying bundle unpacking failed due to gid_t being out of bouds.
Also extended header attributes are detected. See following error:

tar: Ignoring unknown extended header keyword 'SCHILY.dev'
tar: Ignoring unknown extended header keyword 'SCHILY.ino'
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Archive value 346824439072 is out of gid_t range 0..4294967295