### PR TITLE
Use differents meteor settings file for each server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install -g mup
 
 ### Support
 
-First, look at the [troubleshooting](http://meteor-up.com/docs.html#troubleshooting) and [common problems](http://http://meteor-up.com/docs.html#common-problems) sections of the docs. You can also search the [github issues](https://github.com/zodern/meteor-up/issues).
+First, look at the [troubleshooting](http://meteor-up.com/docs.html#troubleshooting) and [common problems](http://meteor-up.com/docs.html#common-problems) sections of the docs. You can also search the [github issues](https://github.com/zodern/meteor-up/issues).
 
 If that doesn't solve the problem, you can:
 - [Create a Github issue](https://github.com/zodern/meteor-up/issues/new)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -895,6 +895,7 @@ module.exports = {
 - [mup-disk](https://www.npmjs.com/package/mup-disk) Shows disk usage and cleans up old files and docker items
 - [mup-redis](https://www.npmjs.com/package/mup-redis) Set up and manage Redis
 - [mup-fix-bin-paths](https://www.npmjs.com/package/mup-fix-bin-paths) Fix npm bin paths that break deploying from Windows
+- [mup-aws-beanstalk](https://github.com/zodern/mup-aws-beanstalk) Deploy using AWS Elsatic Beanstalk. Supports load balancing, auto scaling, and rolling deploys.
 
 If you have created a plugin, create a pull request to add it to this list.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,6 +77,6 @@ Congratulations! Your app is now running on the server, accessible to your poten
 
 ## Next Steps
 
-- [View logs](https://github.com/zodern/meteor-up#other-utility-commands)
-- [Setup SSL](https://github.com/zodern/meteor-up#ssl-support)
-- [View config options](https://github.com/zodern/meteor-up#example-config)
+- [View logs](docs.html#other-utility-commands)
+- [Setup SSL](docs.html#ssl-support)
+- [View config options](docs.html#example-configs)

--- a/src/plugin-api.js
+++ b/src/plugin-api.js
@@ -154,65 +154,40 @@ export default class PluginAPI {
       } else {
         filePath = path.join(this.base, 'settings.json');
       }
-
-      try {
-        this.settings = fs.readFileSync(filePath).toString();
-      } catch (e) {
-        console.log(`Unable to load settings.json at ${filePath}`);
-        if (e.code !== 'ENOENT') {
-          console.log(e);
-        } else {
-          [
-            'It does not exist.',
-            '',
-            'You can create the file with "mup init" or add the option',
-            '"--settings path/to/settings.json" to load it from a',
-            'different location.'
-          ].forEach(text => console.log(text));
-        }
-        process.exit(1);
-      }
-      try {
-        this.settings = parseJson(this.settings);
-      } catch (e) {
-        console.log('Error parsing settings file:');
-        console.log(e.message);
-
-        process.exit(1);
-      }
+      this.settings = this.getSettingsFromPath(filePath);
     }
 
     return this.settings;
   }
 
   getSettingsFromPath(settingsPath) {
-      let filePath = resolvePath(settingsPath);
-      let settings;
-      try {
-        settings = fs.readFileSync(filePath).toString();
-      } catch (e) {
-        console.log(`Unable to load settings.json at ${filePath}`);
-        if (e.code !== 'ENOENT') {
-          console.log(e);
-        } else {
-          [
-            'It does not exist.',
-            '',
-            'You can create the file with "mup init" or add the option',
-            '"--settings path/to/settings.json" to load it from a',
-            'different location.'
-          ].forEach(text => console.log(text));
-        }
-        process.exit(1);
+    let filePath = resolvePath(settingsPath);
+    let settings;
+    try {
+      settings = fs.readFileSync(filePath).toString();
+    } catch (e) {
+      console.log(`Unable to load settings.json at ${filePath}`);
+      if (e.code !== 'ENOENT') {
+        console.log(e);
+      } else {
+        [
+          'It does not exist.',
+          '',
+          'You can create the file with "mup init" or add the option',
+          '"--settings path/to/settings.json" to load it from a',
+          'different location.'
+        ].forEach(text => console.log(text));
       }
-      try {
-        settings = parseJson(settings);
-      } catch (e) {
-        console.log('Error parsing settings file:');
-        console.log(e.message);
+      process.exit(1);
+    }
+    try {
+      settings = parseJson(settings);
+    } catch (e) {
+      console.log('Error parsing settings file:');
+      console.log(e.message);
 
-        process.exit(1);
-      }
+      process.exit(1);
+    }
     return settings;
   }
 

--- a/src/plugin-api.js
+++ b/src/plugin-api.js
@@ -185,6 +185,37 @@ export default class PluginAPI {
     return this.settings;
   }
 
+  getSettingsFromPath(settingsPath) {
+      let filePath = resolvePath(settingsPath);
+      let settings;
+      try {
+        settings = fs.readFileSync(filePath).toString();
+      } catch (e) {
+        console.log(`Unable to load settings.json at ${filePath}`);
+        if (e.code !== 'ENOENT') {
+          console.log(e);
+        } else {
+          [
+            'It does not exist.',
+            '',
+            'You can create the file with "mup init" or add the option',
+            '"--settings path/to/settings.json" to load it from a',
+            'different location.'
+          ].forEach(text => console.log(text));
+        }
+        process.exit(1);
+      }
+      try {
+        settings = parseJson(settings);
+      } catch (e) {
+        console.log('Error parsing settings file:');
+        console.log(e.message);
+
+        process.exit(1);
+      }
+    return settings;
+  }
+
   setConfig(newConfig) {
     this.config = newConfig;
   }

--- a/src/plugin-api.js
+++ b/src/plugin-api.js
@@ -161,7 +161,7 @@ export default class PluginAPI {
   }
 
   getSettingsFromPath(settingsPath) {
-    let filePath = resolvePath(settingsPath);
+    const filePath = resolvePath(settingsPath);
     let settings;
     try {
       settings = fs.readFileSync(filePath).toString();
@@ -188,6 +188,7 @@ export default class PluginAPI {
 
       process.exit(1);
     }
+
     return settings;
   }
 

--- a/src/plugins/meteor/command-handlers.js
+++ b/src/plugins/meteor/command-handlers.js
@@ -272,7 +272,7 @@ export function envconfig(api) {
       hostVars[servers[key].host] = {env: config.servers[key].env};
     }
     if (config.servers[key].settings) {
-      let settings = JSON.stringify(api.getSettingsFromPath(
+      const settings = JSON.stringify(api.getSettingsFromPath(
         config.servers[key].settings));
       if (hostVars[servers[key].host]) {
         hostVars[servers[key].host].env.METEOR_SETTINGS = settings;

--- a/src/plugins/meteor/command-handlers.js
+++ b/src/plugins/meteor/command-handlers.js
@@ -271,6 +271,14 @@ export function envconfig(api) {
     if (config.servers[key].env) {
       hostVars[servers[key].host] = {env: config.servers[key].env};
     }
+    if (config.servers[key].settings) {
+      let settings = JSON.stringify(api.getSettingsFromPath(config.servers[key].settings));
+      if (hostVars[servers[key].host]) {
+        hostVars[servers[key].host].env.METEOR_SETTINGS = settings;
+      } else {
+        hostVars[servers[key].host] = {env: {METEOR_SETTINGS: settings}};
+      }
+    }
   });
 
   list.copy('Sending Environment Variables', {

--- a/src/plugins/meteor/command-handlers.js
+++ b/src/plugins/meteor/command-handlers.js
@@ -272,7 +272,8 @@ export function envconfig(api) {
       hostVars[servers[key].host] = {env: config.servers[key].env};
     }
     if (config.servers[key].settings) {
-      let settings = JSON.stringify(api.getSettingsFromPath(config.servers[key].settings));
+      let settings = JSON.stringify(api.getSettingsFromPath(
+        config.servers[key].settings));
       if (hostVars[servers[key].host]) {
         hostVars[servers[key].host].env.METEOR_SETTINGS = settings;
       } else {

--- a/src/plugins/meteor/validate.js
+++ b/src/plugins/meteor/validate.js
@@ -11,7 +11,8 @@ const schema = joi.object().keys({
       env: joi.object().pattern(
         /[/s/S]*/,
         [joi.string(), joi.number(), joi.bool()]
-      )
+      ),
+      settings: joi.string(),
     })
   ),
   deployCheckWaitTime: joi.number(),

--- a/src/plugins/meteor/validate.js
+++ b/src/plugins/meteor/validate.js
@@ -12,7 +12,7 @@ const schema = joi.object().keys({
         /[/s/S]*/,
         [joi.string(), joi.number(), joi.bool()]
       ),
-      settings: joi.string(),
+      settings: joi.string()
     })
   ),
   deployCheckWaitTime: joi.number(),


### PR DESCRIPTION
This is really useful for me because I deploy to master server and secondary server, my main task need to be performed only on the master server so i need specific settings for the master server. If it can help somebody feel free to merge ;)
Example of my settings file: 

```
meteor: {
        ...
        servers: {
            one: {
                env: {
                    TOKEN: "popopo"
                }
            },
            two: {
                env: {
                    TOKEN: "papapa"
                },
                settings: "secondarySettings.json"
            }
        },
        ...
}
```

If nothing is defined it will use the default settings.json file ;)