### PR TITLE
Default HTTP_FORWARDED_COUNT to 1 for reverse proxy

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -186,6 +186,11 @@ module.exports = {
 
       // The port you access the app on. (optional, default is 80)
       // PORT: 8000
+
+      // The number of proxies in front of your server (optional, default is
+      // 1 with reverse proxy, unused otherwise).
+      // https://docs.meteor.com/api/connections.html
+      // HTTP_FORWARDED_COUNT: 1
     },
 
     // Docker log options (optional)

--- a/src/plugins/proxy/index.js
+++ b/src/plugins/proxy/index.js
@@ -18,6 +18,8 @@ export function prepareConfig(config) {
 
   config.app.env.VIRTUAL_HOST = config.proxy.domains;
   config.app.env.HTTPS_METHOD = config.proxy.ssl && config.proxy.ssl.forceSSL ? 'redirect' : 'noredirect';
+  config.app.env.HTTP_FORWARDED_COUNT =
+    config.app.env.HTTP_FORWARDED_COUNT || 1;
 
   if (config.proxy.ssl && config.proxy.ssl.letsEncryptEmail) {
     config.app.env.LETSENCRYPT_HOST = config.proxy.domains;


### PR DESCRIPTION
This updates the default configuration to set the env variable `HTTP_FORWARDED_COUNT` to 1 when using the reverse proxy.

Per [Meteor documentation](https://docs.meteor.com/api/connections.html), this must be set to an integer representing the number of proxies in front of the Meteor server. If this is not set properly, than the Meteor server-side `connection` object will have an incorrect IP address, typically a private address of `127.x.x.x`, set in `clientAddress`. This will result in being unable to retrieve connected client actual IP addresses. See #844.

This also updates the documentation to show the default, since users will have to increase this number if they add another proxy, such as a CDN, in front of their MUP deployment.

I based this of dev as MUP 1.4 will default to use reverse proxy.

One test does fail but it's unrelated to this PR and happens on the current `dev` branch.

<img width="475" alt="screen shot 2018-02-11 at 11 21 37 am" src="https://user-images.githubusercontent.com/14143246/36075491-c6ad9fbc-0f1d-11e8-98fd-6282f7322304.png">

