### PR TITLE
Add support for CentOS 7 or newer to mup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Meteor Up is a command line tool that allows you to deploy any [Meteor](http://meteor.com) app to your own server.
 
-You can install and use Meteor Up on Linux, Mac and Windows. It can deploy to servers running Ubuntu 14 or newer.
+You can install and use Meteor Up on Linux, Mac and Windows. It can deploy to servers running Ubuntu 14 or newer and CentOS 7 or newer.
 
 This version of Meteor Up is powered by [Docker](http://www.docker.com/), making deployment easy to manage and reducing server specific errors.
 
@@ -86,5 +86,3 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 <a href="https://opencollective.com/meteor-up/sponsor/7/website" target="_blank"><img src="https://opencollective.com/meteor-up/sponsor/7/avatar.svg"></a>
 <a href="https://opencollective.com/meteor-up/sponsor/8/website" target="_blank"><img src="https://opencollective.com/meteor-up/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/meteor-up/sponsor/9/website" target="_blank"><img src="https://opencollective.com/meteor-up/sponsor/9/avatar.svg"></a>
-
-

--- a/src/plugins/docker/assets/docker-setup.sh
+++ b/src/plugins/docker/assets/docker-setup.sh
@@ -14,19 +14,24 @@ install_docker () {
     set -e
     sudo apt-get update
     sudo apt-get -y install wget lxc iptables curl
+    # Install docker
+    wget -qO- https://get.docker.com/ | sudo sh
+    sudo usermod -a -G docker ${USER}
   else
     # Required to update CentOS system
     sudo rm -f /var/run/yum.pid > /dev/null
     sudo yum clean all > /dev/null
     set -e
     sudo yum -y update
-    sudo yum -y install wget lxc iptables curl redhat-lsb-core
+    sudo yum -y install wget lxc iptables curl redhat-lsb-core initscripts
+    # Install docker
+    wget -qO- https://get.docker.com/ | sudo sh
+    sudo usermod -a -G docker ${USER}
+    # start docker on boot
+    sudo chkconfig docker on
   fi
 
-  # Install docker
-  wget -qO- https://get.docker.com/ | sudo sh
-  sudo usermod -a -G docker ${USER}
-
+  # start docker service
   sudo service docker start || sudo service docker restart
 }
 

--- a/src/plugins/docker/assets/docker-setup.sh
+++ b/src/plugins/docker/assets/docker-setup.sh
@@ -5,7 +5,7 @@
 install_docker () {
 # Remove the lock
   set +e
-  if [lsb_release -is]
+  if lsb_release -is > /dev/null
   then
     # Required to update Ubuntu system
     sudo rm /var/lib/dpkg/lock > /dev/null

--- a/src/plugins/docker/assets/docker-setup.sh
+++ b/src/plugins/docker/assets/docker-setup.sh
@@ -5,14 +5,23 @@
 install_docker () {
 # Remove the lock
   set +e
-  sudo rm /var/lib/dpkg/lock > /dev/null
-  sudo rm /var/cache/apt/archives/lock > /dev/null
-  sudo dpkg --configure -a
-  set -e
-
-  # Required to update system
-  sudo apt-get update
-  sudo apt-get -y install wget lxc iptables curl
+  if [lsb_release -is]
+  then
+    # Required to update Ubuntu system
+    sudo rm /var/lib/dpkg/lock > /dev/null
+    sudo rm /var/cache/apt/archives/lock > /dev/null
+    sudo dpkg --configure -a
+    set -e
+    sudo apt-get update
+    sudo apt-get -y install wget lxc iptables curl
+  else
+    # Required to update CentOS system
+    sudo rm -f /var/run/yum.pid > /dev/null
+    sudo yum clean all > /dev/null
+    set -e
+    sudo yum -y update
+    sudo yum -y install wget lxc iptables curl redhat-lsb-core
+  fi
 
   # Install docker
   wget -qO- https://get.docker.com/ | sudo sh


### PR DESCRIPTION
This is to use mup on CentOS VMs as many enterprises still standardize on RedHat Linux. mup has very few dependencies on the distribution. Tested on Google cloud images.