### PR TITLE
Added graceful timeout in seconds

### DIFF
--- a/src/plugins/meteor/assets/meteor-stop.sh
+++ b/src/plugins/meteor/assets/meteor-stop.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 APPNAME=<%= appName %>
+TIMEOUT=<%= gracefulTimeout %>
+
+# Gracefully stopping the meteor application
+sudo docker stop -t $TIMEOUT $APPNAME || :
 
 sudo docker rm -f $APPNAME || :
 sudo docker rm -f $APPNAME-frontend || :

--- a/src/plugins/meteor/assets/templates/start.sh
+++ b/src/plugins/meteor/assets/templates/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 APPNAME=<%= appName %>
+TIMEOUT=<%= gracefulTimeout %>
 CLIENTSIZE=<%= nginxClientUploadLimit %>
 APP_PATH=/opt/$APPNAME
 BUNDLE_PATH=$APP_PATH/current
@@ -28,6 +29,7 @@ echo "Volume" $VOLUME
 >&2 echo "Removing docker containers. Errors about nonexistent endpoints and containers are normal.";
 
 # Remove previous version of the app, if exists
+sudo docker stop -t $TIMEOUT $APPNAME
 sudo docker rm -f $APPNAME
 
 # Remove container network if still exists

--- a/src/plugins/meteor/command-handlers.js
+++ b/src/plugins/meteor/command-handlers.js
@@ -349,7 +349,8 @@ export function stop(api) {
   list.executeScript('Stop Meteor', {
     script: api.resolvePath(__dirname, 'assets/meteor-stop.sh'),
     vars: {
-      appName: config.name
+      appName: config.name,
+      gracefulTimeout: config.gracefulTimeout || 10,
     }
   });
 
@@ -366,7 +367,8 @@ export function restart(api) {
   list.executeScript('Stop Meteor', {
     script: api.resolvePath(__dirname, 'assets/meteor-stop.sh'),
     vars: {
-      appName: config.name
+      appName: config.name,
+      gracefulTimeout: config.gracefulTimeout || 10,
     }
   });
 

--- a/src/plugins/meteor/utils.js
+++ b/src/plugins/meteor/utils.js
@@ -23,6 +23,7 @@ export function addStartAppTask(list, api) {
     script: api.resolvePath(__dirname, 'assets/meteor-start.sh'),
     vars: {
       appName: appConfig.name,
+      gracefulTimeout: appConfig.gracefulTimeout || 10,
       removeImage: isDeploy && !prepareBundleSupported(appConfig.docker)
     }
   });


### PR DESCRIPTION
Added the option `app.gracefulTimeout` to decide many seconds a graceful shutdown is allowed to take - which is - how long docker should wait from calling `docker stop` (which triggers `SIGINT`) to calling `docker rm -f` (which triggers `SIGTERM`).

I don't know at which place the documentation can be updated, so I've left this task open.

The default value of `app.gracefulTimeout` is `10` and is in seconds.

As of how I see it, the other containers don't need a graceful shutdown, or do they? If yes, we need to take into account that e.g. nginx uses a different signal for a graceful shutdown than `SIGINT` - this just as a small note in case it's required.

This is untested though ...