### PR TITLE
Remove mup.cmd necessity for Windows users.

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../index.js')

--- a/bin/run
+++ b/bin/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-
-require('../index.js')
+require('babel-polyfill');
+require('../lib');

--- a/bin/run.cmd
+++ b/bin/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\run" %*

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-require('babel-polyfill');
-require('./lib');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "http://meteor-up.com/",
   "bin": {
-    "mup": "./index.js"
+    "mup": "bin/run"
   },
   "scripts": {
     "prepublish": "npm run build -s",


### PR DESCRIPTION
Moved `index.js` bin script to a `bin` directory along with a new Windows-spesific start script.

This enables non-Powershell Windows users to run Meteor Up using the `mup` command instead of being required to use `mup.cmd` while maintaining the same behaviour for other users.