### PR TITLE
Update docs for meteor 1.8

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -282,6 +282,7 @@ Mup supports Meteor 1.2 and newer, though you might need to change the docker im
 | 1.2 - 1.3 | `kadirahq/meteord` | false | This is the default docker image. When using Meteor 1.2, `app.buildOptions.serverOnly` should be false. |
 | 1.4 - 1.5 | `abernix/meteord:base` | true |  |
 | 1.6 | `abernix/meteord:node-8.4.0-base` | true | |
+| 1.8 | `abernix/meteord:node-8.11.2-base` | true | |
 | 1.2 - 1.6 | `zodern/meteor:root` | true | Automatically uses the correct node version. |
 
 When using an image that supports `Prepare Bundle`, deployments are easier to debug and more reliable.

--- a/src/plugins/default/template/mup.js.sample
+++ b/src/plugins/default/template/mup.js.sample
@@ -32,8 +32,9 @@ module.exports = {
     },
 
     docker: {
-      // change to 'abernix/meteord:base' if your app is using Meteor 1.4 - 1.5
-      image: 'abernix/meteord:node-8.4.0-base',
+      // abernix/meteord:node-8.11.2-base works with Meteor 1.8
+      // If you are using a different version of Meteor, refer to the docs for the correct image to use.
+      image: 'abernix/meteord:node-8.11.2-base',
     },
 
     // Show progress bar while uploading bundle to server

--- a/src/plugins/default/template/mup.js.sample
+++ b/src/plugins/default/template/mup.js.sample
@@ -33,7 +33,8 @@ module.exports = {
 
     docker: {
       // abernix/meteord:node-8.11.2-base works with Meteor 1.8
-      // If you are using a different version of Meteor, refer to the docs for the correct image to use.
+      // If you are using a different version of Meteor,
+      // refer to the docs for the correct image to use.
       image: 'abernix/meteord:node-8.11.2-base',
     },
 


### PR DESCRIPTION
Meteor 1.8 now uses Node 8.11.2. 
This PR updates docker image references, in the Docs.