### PR TITLE
Update SSL Doc

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -539,7 +539,8 @@ module.exports = {
       // Enable let's encrypt to create free certificates.
       // The email is used by Let's Encrypt to notify you when the
       // certificates are close to expiring.
-      letsEncryptEmail: 'email@domain.com'
+      // You can choose it arbitrarily
+      letsEncryptEmail: 'your@email.com'
     }
   }
 };


### PR DESCRIPTION
It was still a bit unclear that `letsEncryptEmail` is totally arbitrary, I added a comment.

Also, I had to stop the app with `mup stop` to make `mup setup` work. Otherwise I had this error on `mup setup`:
```
Error response from daemon: endpoint mup-nginx-proxy not found
Error: No such container: mup-nginx-proxy-letsencrypt
```
Is this normal?