### PR TITLE
Use Remote docker Image instead of building. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ coverage
 tests/ssh/
 .nyc_output/
 tests/validate-tmp
+.history
+.cache/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.pkg.github.com/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://npm.pkg.github.com/
+@nudger-labs:registry=https://npm.pkg.github.com/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.6 - April 27, 2019
+- Mongo and nginx logs are now rotated and limited to 700mb
+- Fix error when running `mup setup` without a `servers` object in the config.
+
 ## 1.4.5 - June 9, 2018
 - Add option to keep the app running during Prepare Bundle
 - Add `app.docker.prepareBundle` to example config

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,6 +5,9 @@ title: 'Plugins'
 ## List of plugins
   
   - [mup-aws-beanstalk](https://github.com/zodern/mup-aws-beanstalk) Deploy using AWS Elastic Beanstalk. Supports load balancing, auto scaling, and rolling deploys
+  - [mup-node](https://github.com/zodern/mup-node) Deploy node apps with Meteor Up
+  - [mup-docker-deploy](https://github.com/zodern/mup-docker-deploy) Use a custom Dockerfile to deploy any type of app
+  - [mup-cloud-front](https://github.com/zodern/mup-cloud-front) Setup and use CloudFlare, with support for rolling deploys
   - [mup-disk](https://www.npmjs.com/package/mup-disk) Shows disk usage and cleans up old files and docker items
   - [mup-redis](https://www.npmjs.com/package/mup-redis) Set up and manage Redis
   - [mup-fix-bin-paths](https://www.npmjs.com/package/mup-fix-bin-paths) Fix npm bin paths that break deploying from Windows

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.5.0",
+  "version": "1.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1495,6 +1495,7 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -2571,6 +2572,535 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4192,9 +4722,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,5 +1,5 @@
 {
-  "name": "mup",
+  "name": "@nudger-labs/mup",
   "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zodern/meteor-up.git"
+    "url": "git://github.com/nudger-labs/meteor-up.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "keywords": [
     "meteor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.5.0",
+  "version": "1.4.9",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mup",
+  "name": "@nudger-labs/mup",
   "version": "1.4.8",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nudger-labs/mup",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Production Quality Meteor Deployments",
   "main": "lib/index.js",
   "repository": {

--- a/src/plugins/docker/command-handlers.js
+++ b/src/plugins/docker/command-handlers.js
@@ -42,7 +42,7 @@ export function setup(api) {
   log('exec => mup docker setup');
   const config = api.getConfig();
   const swarmEnabled = config.swarm;
-  const servers = Object.keys(config.servers);
+  const servers = Object.keys(config.servers || {});
 
   const list = nodemiral.taskList('Setup Docker');
 

--- a/src/plugins/meteor/assets/meteor-start.sh
+++ b/src/plugins/meteor/assets/meteor-start.sh
@@ -3,6 +3,15 @@
 set -e
 
 APP_DIR=/opt/<%=appName %>
+
+<% if(docker.remoteImage){ %>
+  echo "Running docker with remote Image" <%= docker.remoteImage %>
+  cd $APP_DIR
+  # start app
+  sudo bash config/start.sh
+
+<% } else {  %>
+
 IMAGE=mup-<%= appName.toLowerCase() %>
 
 <% if (removeImage) { %>
@@ -17,7 +26,7 @@ docker images
 # save the last known version
 cd $APP_DIR
 if sudo docker image inspect $IMAGE:latest >/dev/null; then
-  echo "using image"
+  echo "using image HI"
   sudo rm -rf current || true
 else
   echo "using bundle"
@@ -38,3 +47,4 @@ fi
 
 # start app
 sudo bash config/start.sh
+<% } %>

--- a/src/plugins/meteor/assets/templates/start.sh
+++ b/src/plugins/meteor/assets/templates/start.sh
@@ -15,9 +15,8 @@ IMAGE=<% if(docker.remoteImage){ %><%= docker.remoteImage %>
 VOLUME="--volume=$BUNDLE_PATH:/bundle"
 LOCAL_IMAGE=false
 
-sudo docker image inspect $IMAGE >/dev/null || IMAGE=<%= docker.image %>
-
-if [ $IMAGE == $APP_IMAGE:latest  ]; then
+# sudo docker image inspect $IMAGE >/dev/null || IMAGE=<%= docker.image %>
+if sudo docker image inspect $IMAGE >/dev/null; then
   VOLUME=""
   LOCAL_IMAGE=true
 fi

--- a/src/plugins/meteor/assets/templates/start.sh
+++ b/src/plugins/meteor/assets/templates/start.sh
@@ -10,7 +10,8 @@ BIND=<%= bind %>
 NGINX_PROXY_VERSION=latest
 LETS_ENCRYPT_VERSION=latest
 APP_IMAGE=mup-<%= appName.toLowerCase() %>
-IMAGE=$APP_IMAGE:latest
+IMAGE=<% if(docker.remoteImage){ %><%= docker.remoteImage %>
+  <% } else { %>$APP_IMAGE:latest <% } %>
 VOLUME="--volume=$BUNDLE_PATH:/bundle"
 LOCAL_IMAGE=false
 
@@ -52,8 +53,8 @@ sudo docker network disconnect bridge -f $APPNAME-nginx-proxy
 # We don't need to fail the deployment because of a docker hub downtime
 if [ $LOCAL_IMAGE == "false" ]; then
   set +e
-  sudo docker pull <%= docker.image %>
-  echo "Pulled <%= docker.image %>"
+  sudo docker pull $IMAGE
+  echo "Pulled "$IMAGE
   set -e
 
 else
@@ -83,7 +84,7 @@ sudo docker run \
   <% } %> \
   --name=$APPNAME \
   $IMAGE
-echo "Ran <%= docker.image %>"
+echo "Ran" $IMAGE
 sleep 15s
 
 <% if(typeof sslConfig === "object") { %>

--- a/src/plugins/meteor/command-handlers.js
+++ b/src/plugins/meteor/command-handlers.js
@@ -197,7 +197,7 @@ export async function push(api) {
 
 export function envconfig(api) {
   log('exec => mup meteor envconfig');
-
+  
   const config = api.getConfig().app;
   const servers = api.getConfig().servers;
   let bindAddress = '0.0.0.0';

--- a/src/plugins/meteor/utils.js
+++ b/src/plugins/meteor/utils.js
@@ -22,6 +22,7 @@ export function addStartAppTask(list, api) {
   list.executeScript('Start Meteor', {
     script: api.resolvePath(__dirname, 'assets/meteor-start.sh'),
     vars: {
+      docker: appConfig.docker,
       appName: appConfig.name,
       removeImage: isDeploy && !prepareBundleSupported(appConfig.docker)
     }

--- a/src/plugins/meteor/validate.js
+++ b/src/plugins/meteor/validate.js
@@ -23,6 +23,7 @@ const schema = joi.object().keys({
     image: joi.string().trim(),
     imagePort: joi.number(),
     imageFrontendServer: joi.string(),
+    remoteImage: joi.string(),
     args: joi.array().items(joi.string()),
     bind: joi.string().trim(),
     prepareBundle: joi.bool(),

--- a/src/plugins/mongo/assets/mongo-start.sh
+++ b/src/plugins/mongo/assets/mongo-start.sh
@@ -25,6 +25,8 @@ sudo docker run \
   --volume=<%= mongoDbDir %>:/data/db \
   --volume=/opt/mongodb/mongodb.conf:/mongodb.conf \
   --name=mongodb \
+  --log-opt max-size=100m \
+  --log-opt max-file=7 \
   mongo:$MONGO_VERSION mongod -f /mongodb.conf
 
 

--- a/src/plugins/mongo/assets/mongo-start.sh
+++ b/src/plugins/mongo/assets/mongo-start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MONGO_VERSION=<%= mongoVersion %>
+MONGO_BINDIP=<%= mongoBindIp %>
 
 set -e
 
@@ -21,7 +22,7 @@ echo "Running mongo:<%= mongoVersion %>"
 sudo docker run \
   -d \
   --restart=unless-stopped \
-  --publish=127.0.0.1:27017:27017 \
+  --publish=<%= mongoBindIp %>:27017:27017 \
   --volume=<%= mongoDbDir %>:/data/db \
   --volume=/opt/mongodb/mongodb.conf:/mongodb.conf \
   --name=mongodb \

--- a/src/plugins/mongo/assets/mongo-start.sh
+++ b/src/plugins/mongo/assets/mongo-start.sh
@@ -17,7 +17,7 @@ sudo docker rm -f mongodb
 
 set -e
 
-echo "Running mongo:<%= mongoVersion %>"
+echo "Running mongo:<%= mongoVersion %> on <%= mongoBindIp %>"
 
 sudo docker run \
   -d \

--- a/src/plugins/mongo/assets/mongo-start.sh
+++ b/src/plugins/mongo/assets/mongo-start.sh
@@ -40,7 +40,7 @@ while [[ true ]]; do
   sleep 1
   elaspsed=$((elaspsed+1))
   sudo docker exec mongodb mongo --eval \
-    'rs.initiate({_id: "meteor", members: [{_id: 0, host: "127.0.0.1:27017"}]});' \
+    'rs.initiate({_id: "meteor", members: [{_id: 0, host: "<%= mongoBindIp %>:27017"}]});' \
     && exit 0
   
   if [ "$elaspsed" "==" "$limit" ]; then

--- a/src/plugins/mongo/command-handlers.js
+++ b/src/plugins/mongo/command-handlers.js
@@ -83,6 +83,7 @@ export function start(api) {
     script: api.resolvePath(__dirname, 'assets/mongo-start.sh'),
     vars: {
       mongoVersion: config.version || '3.4.1',
+      mongoBindIp: config.bindIp || '127.0.0.1',
       mongoDbDir: '/var/lib/mongodb'
     }
   });
@@ -136,6 +137,7 @@ export async function status(api) {
   }
 
   const mongoVersion = mongoStatus.version;
+  const mongoBindIp = mongoStatus.bindIp;
   const connections = mongoStatus.connections.current;
   const storageEngine = mongoStatus.storageEngine.name;
 
@@ -188,6 +190,7 @@ export async function status(api) {
   console.log(chalk[restartCountColor](`  Restarted ${restartCount} times`));
   console.log(`  Running since ${createdTime}`);
   console.log(`  Version: ${mongoVersion}`);
+  console.log(`  BindIP: ${mongoBindIp}`);
   console.log(`  Connections: ${connections}`);
   console.log(`  Storage Engine: ${storageEngine}`);
 }

--- a/src/plugins/mongo/validate.js
+++ b/src/plugins/mongo/validate.js
@@ -7,6 +7,7 @@ const schema = joi.object().keys({
   oplog: joi.bool(),
   port: joi.number(),
   version: joi.string(),
+  bindIp: joi.string(),
   servers: joi.object().keys().required()
 });
 

--- a/src/plugins/proxy/assets/templates/start.sh
+++ b/src/plugins/proxy/assets/templates/start.sh
@@ -48,7 +48,9 @@ sudo docker run \
   -p $HTTPS_PORT:443 \
   --name $APPNAME \
   --env-file=$ENV_FILE \
-  --restart=always\
+  --restart=always \
+  --log-opt max-size=100m \
+  --log-opt max-file=7 \
   -v /opt/$APPNAME/mounted-certs:/etc/nginx/certs \
   -v /opt/$APPNAME/config/vhost.d:/etc/nginx/vhost.d \
   -v /opt/$APPNAME/config/html:/usr/share/nginx/html \
@@ -63,6 +65,8 @@ sudo docker run -d \
   --env-file=$ENV_FILE_LETSENCRYPT \
   --restart=always \
   --volumes-from $APPNAME \
+  --log-opt max-size=100m \
+  --log-opt max-file=3 \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   jrcs/letsencrypt-nginx-proxy-companion
 echo "Ran jrcs/letsencrypt-nginx-proxy-companion"


### PR DESCRIPTION
I recognize this PR is not in a state to merge but I hope it can be taken apart and added to 1.5. 
I use this currently for my company, we use Github workflow to automatically build our Meteor Docker Image and push to Docker hub. We then add the image tag from Docker hub to the mup.js config as `docker.remoteImage` this PR looks for that config option and uses it instead of the local build. 
It works very well, you can switch from local build to remoteImage easily, and it allows a to store a history of all our images/versions which make it very easy to roll-back when needed.