### PR TITLE
Added support for using Docker volumes with the Nginx proxy

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -642,7 +642,14 @@ module.exports = {
 
     // (optional, default=10M) Limit for the size of file uploads.
     // Set to 0 disables the limit.
-    clientUploadLimit: '50M'
+    clientUploadLimit: '50M',
+
+    // lets you add docker volumes to Nginx (optional)
+    // Can be used to serve static files
+    volumes: {
+      // passed as '-v /host/path:/container/path:ro' to the docker run command
+      '/host/path': '/container/path:ro'    
+    }
   }
 };
 ```

--- a/src/plugins/proxy/assets/templates/start.sh
+++ b/src/plugins/proxy/assets/templates/start.sh
@@ -56,6 +56,7 @@ sudo docker run \
   -v /opt/$APPNAME/config/html:/usr/share/nginx/html \
   -v /opt/$APPNAME/config/nginx-default.conf:/etc/nginx/conf.d/my_proxy.conf:ro \
   -v /var/run/docker.sock:/tmp/docker.sock:ro \
+  <% for(var volume in volumes) { %>-v <%= volume %>:<%= volumes[volume] %> <% } %> \
   jwilder/nginx-proxy
 echo "Ran nginx-proxy as $APPNAME"
 

--- a/src/plugins/proxy/validate.js
+++ b/src/plugins/proxy/validate.js
@@ -16,6 +16,7 @@ const schema = joi.object().keys({
   nginxServerConfig: joi.string(),
   nginxLocationConfig: joi.string(),
   clientUploadLimit: joi.string(),
+  volumes: joi.object(),
   shared: joi.object().keys({
     clientUploadLimit: joi.alternatives().try(joi.number(), joi.string()),
     httpPort: joi.number(),


### PR DESCRIPTION
Greetings, @zodern.

Changes:

* Created option `proxy.volumes`. Can be used to serve static files from Nginx.
* Updated the Advanced configuration section of `docs.md`, added example of usage with read-only volume.

Best wishes,
Sergey.