### PR TITLE
Fix deploying to non root user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ env:
   - TEST_PLUGINS='meteor' TEST_OPTIONS="--non-root"
   - TEST_PLUGINS='docker,mongo,proxy,default' TEST_OPTIONS="--non-root"
 
+jobs:
+  exclude:
+  - node_js: "8"
+    env: TEST_PLUGINS='meteor' TEST_OPTIONS="--non-root"
+  - node_js: "8"
+    env: TEST_PLUGINS='docker,mongo,proxy,default' TEST_OPTIONS="--non-root"
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ node_js:
   - "14"
 
 env:
-  - TEST_PLUGINS='default'
   - TEST_PLUGINS='meteor'
-  - TEST_PLUGINS='mongo,docker,proxy'
-  - TEST_PLUGINS='default' TEST_OPTIONS="--non-root"
+  - TEST_PLUGINS='docker,mongo,proxy,default'
   - TEST_PLUGINS='meteor' TEST_OPTIONS="--non-root"
-  - TEST_PLUGINS='mongo,docker,proxy' TEST_OPTIONS="--non-root"
+  - TEST_PLUGINS='docker,mongo,proxy,default' TEST_OPTIONS="--non-root"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ node_js:
   - "14"
 
 env:
-  - TEST_PLUGIN='default'
-  - TEST_PLUGIN='meteor'
-  - TEST_PLUGIN='mongo'
-  - TEST_PLUGIN='docker'
-  - TEST_PLUGIN='proxy'
+  - TEST_PLUGINS='default'
+  - TEST_PLUGINS='meteor'
+  - TEST_PLUGINS='mongo,docker,proxy'
+  - TEST_OPTIONS="--non-root"
+  - TEST_OPTIONS=""
 
 services:
   - docker
@@ -18,4 +18,4 @@ services:
 before_script:
   - echo 'DOCKER_OPTS="--storage-driver=devicemapper"' | sudo tee --append /etc/default/docker >/dev/null && sudo service docker restart
 
-script: npm run test -- --plugin="$TEST_PLUGIN" --skip-pull
+script: npm run test -- --plugins="$TEST_PLUGIN" $TEST_PLUGINS

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ services:
 before_script:
   - echo 'DOCKER_OPTS="--storage-driver=devicemapper"' | sudo tee --append /etc/default/docker >/dev/null && sudo service docker restart
 
-script: npm run test -- --plugins="$TEST_PLUGIN" $TEST_PLUGINS
+script: npm run test -- --plugins="$TEST_PLUGINS" $TEST_OPTIONS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
 sudo: required
 
 language: node_js
-node_js:
-  - "8"
-  - "14"
-
-env:
-  - TEST_PLUGINS='meteor'
-  - TEST_PLUGINS='docker,mongo,proxy,default'
-  - TEST_PLUGINS='meteor' TEST_OPTIONS="--non-root"
-  - TEST_PLUGINS='docker,mongo,proxy,default' TEST_OPTIONS="--non-root"
 
 jobs:
-  exclude:
+  include:
   - node_js: "8"
     env: TEST_PLUGINS='meteor' TEST_OPTIONS="--non-root"
   - node_js: "8"
     env: TEST_PLUGINS='docker,mongo,proxy,default' TEST_OPTIONS="--non-root"
+  - node_js: "14"
+    env: TEST_PLUGINS='meteor'
+  - node_js: "14"
+    env: TEST_PLUGINS='docker,mongo,proxy,default'
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ env:
   - TEST_PLUGINS='default'
   - TEST_PLUGINS='meteor'
   - TEST_PLUGINS='mongo,docker,proxy'
-  - TEST_OPTIONS="--non-root"
-  - TEST_OPTIONS=""
+  - TEST_PLUGINS='default' TEST_OPTIONS="--non-root"
+  - TEST_PLUGINS='meteor' TEST_OPTIONS="--non-root"
+  - TEST_PLUGINS='mongo,docker,proxy' TEST_OPTIONS="--non-root"
 
 services:
   - docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,9 @@ To run the test in parallel, add a matching regex to the `<meteor-up dir>/tests/
 
 `--path <test files>` Defaults to `src/**/__tests__/**/*.js`
 
-`--plugin <plugin name>` Runs tests for plugin. Overrides `--path`
+`--plugins mocha,meter` Runs tests for the plugins, separated by commas. Overrides `--path`
 
-`--skip-pull` To speedup running the tests, it creates a docker image before the first run that has docker installed and has pulled all of the images used during the tests. This option disables creating or using the image.
+`--non-root` Uses a non-root user in the docker container it deploys to
 
 For example:
 ```

--- a/src/plugin-api.js
+++ b/src/plugin-api.js
@@ -529,7 +529,7 @@ export default class PluginAPI {
       throw error;
     }
 
-    const result = await this.runSSHCommand(manager, `docker service inspect ${serviceName}`);
+    const result = await this.runSSHCommand(manager, `sudo docker service inspect ${serviceName}`);
     let serviceInfo = null;
 
     try {

--- a/src/plugins/default/__tests__/index.js
+++ b/src/plugins/default/__tests__/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
+import { before, describe, it } from 'mocha';
 import chai, { expect } from 'chai';
 import { countOccurences, runSSHCommand } from '../../../utils';
-import { describe, it } from 'mocha';
 import chaiString from 'chai-string';
 import fs from 'fs';
 import os from 'os';
@@ -15,6 +15,14 @@ const servers = require('../../../../tests/fixtures/servers');
 
 describe('module - default', function() {
   this.timeout(900000);
+
+  before(async () => {
+    const serverInfo = servers.mymeteor;
+    await runSSHCommand(
+      serverInfo,
+      'sudo docker rm -f $(sudo docker ps -a -q)'
+    );
+  });
 
   describe('deploy', () => {
     it('should deploy meteor app on "meteor" vm', async () => {

--- a/src/plugins/docker/assets/init-swarm.sh
+++ b/src/plugins/docker/assets/init-swarm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker swarm init --advertise-addr <%= host %>
+sudo docker swarm init --advertise-addr <%= host %>

--- a/src/plugins/docker/assets/swarm-demote.sh
+++ b/src/plugins/docker/assets/swarm-demote.sh
@@ -8,7 +8,7 @@ elaspsed=0
 # for it to finish becoming a manager.
 while [[ true ]]; do
 
-  docker node demote \
+  sudo docker node demote \
     <% for(var index in nodeIds) { %> \
     <%= nodeIds[index] %> \
     <% } %> \
@@ -22,4 +22,3 @@ while [[ true ]]; do
     exit 1
   fi
 done
-

--- a/src/plugins/docker/assets/swarm-join.sh
+++ b/src/plugins/docker/assets/swarm-join.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker swarm join --token <%= token %> <%= managerIP %>
+sudo docker swarm join --token <%= token %> <%= managerIP %>

--- a/src/plugins/docker/assets/swarm-labels.sh
+++ b/src/plugins/docker/assets/swarm-labels.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 <% for(var index in toAdd) { %>
-docker node update <%- toAdd[index].node %> \
+sudo docker node update <%- toAdd[index].node %> \
     --label-add <%- toAdd[index].label %>=<%- toAdd[index].value %>
 <% } %>
 
 <% for(var index in toRemove) { %>
-docker node update <%- toRemove[index].node %> \
+sudo docker node update <%- toRemove[index].node %> \
     --label-rm <%- toRemove[index].label %>
 <% } %>

--- a/src/plugins/docker/assets/swarm-leave.sh
+++ b/src/plugins/docker/assets/swarm-leave.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker swarm leave --force || true
+sudo docker swarm leave --force || true

--- a/src/plugins/docker/assets/swarm-promote.sh
+++ b/src/plugins/docker/assets/swarm-promote.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker node promote \
+sudo docker node promote \
     <% for(var index in nodeIds) { %> \
     <%= nodeIds[index] %> \
     <% } %> \

--- a/src/plugins/meteor/__tests__/index.js
+++ b/src/plugins/meteor/__tests__/index.js
@@ -15,6 +15,14 @@ const servers = require('../../../../tests/fixtures/servers');
 describe('module - meteor', function() {
   this.timeout(600000);
 
+  before(async () => {
+    const serverInfo = servers.mymeteor;
+    await runSSHCommand(
+      serverInfo,
+      'sudo docker rm -f $(sudo docker ps -a -q)'
+    );
+  });
+
   describe('setup', () => {
     it('should setup environment on "meteor" vm', async () => {
       const serverInfo = servers.mymeteor;

--- a/src/plugins/meteor/__tests__/index.js
+++ b/src/plugins/meteor/__tests__/index.js
@@ -140,7 +140,7 @@ describe('module - meteor', function() {
     before(async () => {
       await runSSHCommand(
         serverInfo,
-        'docker network create mup-tests'
+        'sudo docker network create mup-tests'
       );
     });
 
@@ -195,7 +195,7 @@ describe('module - meteor', function() {
       const out = sh.exec('mup deploy --cached-build --config mup.user-network.js');
       const sshOut = await runSSHCommand(
         serverInfo,
-        'docker inspect myapp'
+        'sudo docker inspect myapp'
       );
       const networks = JSON.parse(sshOut.output)[0].NetworkSettings.Networks;
 
@@ -211,7 +211,7 @@ describe('module - meteor', function() {
       const out = sh.exec('mup deploy --cached-build --config mup.no-bridge.js');
       const sshOut = await runSSHCommand(
         serverInfo,
-        'docker inspect myapp'
+        'sudo docker inspect myapp'
       );
       const networks = JSON.parse(sshOut.output)[0].NetworkSettings.Networks;
       await checkDeploy(out, '<title>helloapp-new</title>');

--- a/src/plugins/meteor/__tests__/swarm.js
+++ b/src/plugins/meteor/__tests__/swarm.js
@@ -19,7 +19,7 @@ async function checkRunning() {
 
   const sshService = await runSSHCommand(
     serverInfo,
-    'docker service inspect myapp-service'
+    'sudo docker service inspect myapp-service'
   );
 
   expect(sshService.code).to.equal(0);
@@ -84,7 +84,7 @@ describe('module - meteor swarm', function() {
 
       const sshService = await runSSHCommand(
         serverInfo,
-        'docker service inspect myapp-service'
+        'sudo docker service inspect myapp-service'
       );
 
       expect(sshService.code).to.equal(1);

--- a/src/plugins/meteor/assets/meteor-start.sh
+++ b/src/plugins/meteor/assets/meteor-start.sh
@@ -12,7 +12,7 @@ echo "Removing images"
 # This command is only run during a deploy.
 # Removes the latest image, so the start script will use the bundle instead
 sudo docker rmi $IMAGE:latest || true
-docker images
+sudo docker images
 <% } %>
 
 # save the last known version

--- a/src/plugins/meteor/assets/templates/start.sh
+++ b/src/plugins/meteor/assets/templates/start.sh
@@ -27,7 +27,7 @@ fi
   # We want this pull to fail on error since
   # otherwise we might try to run an old version of the app
   set -e
-  docker pull $IMAGE
+  sudo docker pull $IMAGE
   set +e
 <% } %>
 

--- a/src/plugins/mongo/__tests__/index.js
+++ b/src/plugins/mongo/__tests__/index.js
@@ -44,7 +44,7 @@ describe('module - mongo', function() {
       const sshOut = await runSSHCommand(serverInfo, 'tree -pufi /opt');
 
       expect(sshOut.code).to.be.equal(0);
-      expect(countOccurences('mongodb.conf', sshOut.output)).to.be.equal(1);
+      expect(countOccurences('mongo-start-new.sh', sshOut.output)).to.be.equal(1);
     });
   });
 

--- a/src/plugins/proxy/__tests__/index.js
+++ b/src/plugins/proxy/__tests__/index.js
@@ -31,7 +31,7 @@ describe('module - proxy', function() {
       expect(out.output).to.have.entriesCount('Setup proxy', 1);
       expect(out.output).to.have.entriesCount('Start proxy: SUCCESS', 1);
 
-      out = await runSSHCommand(serverInfo, 'docker ps');
+      out = await runSSHCommand(serverInfo, 'sudo docker ps');
 
       expect(out.code).to.equal(0);
       expect(out.output).to.have.entriesCount('mup-nginx-proxy', 2);

--- a/src/server-info.js
+++ b/src/server-info.js
@@ -47,15 +47,15 @@ export const builtInParsers = {
 
 export const _collectors = {
   swarm: {
-    command: 'docker info --format \'{{json .Swarm}}\'',
+    command: 'sudo docker info --format \'{{json .Swarm}}\'',
     parser: builtInParsers.json
   },
   swarmNodes: {
-    command: 'docker node inspect $(docker node ls -q) --format \'{{json .}}\'',
+    command: 'sudo docker node inspect $(sudo docker node ls -q) --format \'{{json .}}\'',
     parser: parseJSONArray
   },
   swarmToken: {
-    command: 'docker swarm join-token worker -q',
+    command: 'sudo docker swarm join-token worker -q',
     parser(stdout, code) {
       if (code === 0 && stdout.indexOf('Error response') === -1) {
         return stdout.trim();
@@ -65,7 +65,7 @@ export const _collectors = {
     }
   },
   images: {
-    command: 'docker images --format \'{{json .}}\'',
+    command: 'sudo docker images --format \'{{json .}}\'',
     parser: parseJSONArray
   }
 };

--- a/src/tasks/assets/create-service.sh
+++ b/src/tasks/assets/create-service.sh
@@ -15,7 +15,7 @@ UPDATE_FAILURE_ACTION=<%= updateFailureAction %>
 UPDATE_PARALLELISM=<%= updateParallelism %>
 UPDATE_DELAY=<%= updateDelay %>
 
-docker service create \
+sudo docker service create \
   <%- endpointMode !== 'dnsrr' ? '--publish=$PUBLISHED_PORT:$TARGET_PORT' : '' %> \
   <%- envFile ? '--env-file=' + envFile : '' %> \
   <%- env ? Object.keys(env).map(key => `--env ${key}=${env[key]} `).join(' ') : '' %> \

--- a/src/tasks/assets/restart-service.sh
+++ b/src/tasks/assets/restart-service.sh
@@ -3,4 +3,4 @@ set -e
 
 NAME="<%= name %>"
 
-docker service update --force $NAME
+sudo docker service update --force $NAME

--- a/src/tasks/assets/stop-service.sh
+++ b/src/tasks/assets/stop-service.sh
@@ -3,4 +3,4 @@ set -e
 
 NAME=<%= name %>
 
-docker service rm $NAME || true
+sudo docker service rm $NAME || true

--- a/src/tasks/assets/update-service.sh
+++ b/src/tasks/assets/update-service.sh
@@ -5,7 +5,7 @@ set -v
 
 NAME="<%= name %>"
 
-docker service update \
+sudo docker service update \
   <%= image ? `--image ${image}` : '' %> \
   <%- envAdd.length ? envAdd.map(env => `--env-add=${env.name}=${env.value}`).join(' ') : '' %> \
   <%- envRemove.length ? envRemove.map(env => `--env-rm=${env.name}`).join(' ') : '' %> \

--- a/tests/fixtures/Dockerfile
+++ b/tests/fixtures/Dockerfile
@@ -29,5 +29,13 @@ COPY ./docker.conf /etc/init.d/docker
 RUN chmod +x /etc/init.d/docker && \
   update-rc.d docker defaults
 
+RUN groupadd -r normal-user && \
+    useradd -s /bin/bash -r -g normal-user normal-user && \
+    adduser normal-user sudo && \
+    mkdir -p /home/normal-user/.ssh && \
+    chown -R normal-user:normal-user /home/normal-user/.ssh && \
+    echo normal-user:password | chpasswd && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo
+
 #Expose ssh port
 EXPOSE 22

--- a/tests/run.js
+++ b/tests/run.js
@@ -44,6 +44,10 @@ var containerId = sh.exec(
 sh.exec(`docker exec ${containerId} sudo service docker start`);
 sh.exec(`docker exec ${containerId} cp ${userPath}/.ssh/authorized_keys2 ${userPath}/.ssh/authorized_keys`);
 
+if (user !== 'root') {
+  sh.exec(`docker exec ${containerId} chown -R ${user}:${user} ${userPath}/.ssh`);
+}
+
 var watch = argv.watch ? '--watch' : '';
 
 var files = argv.path ? argv.path : 'src/**/__tests__/**/*.js';

--- a/tests/run.js
+++ b/tests/run.js
@@ -9,14 +9,16 @@ require('./setup.js');
 
 var mupDir = process.cwd();
 var keyPath = path.resolve(mupDir, 'tests/fixtures/ssh/new.pub');
+var user = argv.nonRoot ? 'normal-user' : 'root';
+var userPath = user === 'root' ? '/root' : `/home/${user}`;
 
-sh.env.PROD_SERVER_USER = 'root';
+sh.env.PROD_SERVER_USER = user;
 sh.env.PROD_SERVER = '127.0.0.1';
 sh.env.PROD_SERVER_PORT = '3500';
 sh.env.PROD_SERVER_PEM = path.resolve(mupDir, 'tests/fixtures/ssh/new');
 sh.env.MUP_SKIP_UPDATE_CHECK = 'true';
 
-var keyVolume = `-v ${keyPath}:/root/.ssh/authorized_keys2`;
+var keyVolume = `-v ${keyPath}:${userPath}/.ssh/authorized_keys2`;
 var publish = '-p 127.0.0.1:3500:22';
 var image = 'mup-tests-server-docker';
 var dockerVolume = '-v mup-test-docker-data:/var/lib/docker';
@@ -40,17 +42,22 @@ var containerId = sh.exec(
 ).output.trim();
 
 sh.exec(`docker exec ${containerId} sudo service docker start`);
-sh.exec(`docker exec ${containerId} cp /root/.ssh/authorized_keys2 /root/.ssh/authorized_keys`);
+sh.exec(`docker exec ${containerId} cp ${userPath}/.ssh/authorized_keys2 ${userPath}/.ssh/authorized_keys`);
 
-var watch = argv.watch ? ' --watch' : '';
-var files = argv.path ? argv.path : ' src/**/__tests__/**/*.js';
-if (argv.plugin) {
-  files = ` src/plugins/${argv.plugin}/__tests__/**/*.js`;
+var watch = argv.watch ? '--watch' : '';
+
+var files = argv.path ? argv.path : 'src/**/__tests__/**/*.js';
+if (argv.plugins) {
+  files = argv.plugins
+    .split(',')
+    .filter(plugin => plugin.length > 0)
+    .map(plugin => `src/plugins/${plugin}/__tests__/**/*.js`)
+    .join(' ');
 }
 
 var g = argv.g ? ` -g ${argv.g}` : '';
-var command = `npm run test:module -- ${files}${watch}${g}`;
-
+var command = `npm run test:module -- ${watch} ${g} ${files}`;
+console.log('=> COMMAND', command);
 var testCode = sh.exec(command)
   .code;
 


### PR DESCRIPTION
Deploying to non-root users is occasionally broken in updates. This adds a new mode for the tests to deploy to a non-root user. In CI, we've always run the tests twice for two node versions. We now will use a non-root user for the tests run with one of the node versions, and the root user for the tests run with the other node version.