### PR TITLE
Fixes missing docker login when using private registry

### DIFF
--- a/src/plugins/meteor/assets/meteor-start.sh
+++ b/src/plugins/meteor/assets/meteor-start.sh
@@ -6,6 +6,17 @@ APP_DIR=/opt/<%=appName %>
 IMAGE=mup-<%= appName.toLowerCase() %>
 PRIVATE_REGISTRY=<%- privateRegistry ? 0 : 1 %>
 
+<% if (privateRegistry) { %>
+  PRIVATE_REGISTRY_USERNAME='<%= privateRegistry.username %>'
+  PRIVATE_REGISTRY_PASSWORD='<%= privateRegistry.password %>'
+  PRIVATE_REGISTRY_HOST='<%= privateRegistry.host %>'
+<% } %>
+
+<% if (privateRegistry) { %>
+  echo "Login into private registry"
+  echo $PRIVATE_REGISTRY_PASSWORD | sudo -S docker login --password-stdin --username $PRIVATE_REGISTRY_USERNAME $PRIVATE_REGISTRY_HOST
+<% } %>
+
 <% if (removeImage) { %>
 echo "Removing images"
 # Run when the docker image doesn't support prepare-bundle.sh.

--- a/src/plugins/meteor/assets/prepare-bundle.sh
+++ b/src/plugins/meteor/assets/prepare-bundle.sh
@@ -8,6 +8,12 @@ IMAGE_PREFIX=<%- imagePrefix %>
 IMAGE=$IMAGE_PREFIX'<%= appName.toLowerCase() %>'
 USE_BUILDKIT=<%= useBuildKit ? 1 : 0 %>
 
+<% if (privateRegistry) { %>
+  PRIVATE_REGISTRY_USERNAME='<%= privateRegistry.username %>'
+  PRIVATE_REGISTRY_PASSWORD='<%= privateRegistry.password %>'
+  PRIVATE_REGISTRY_HOST='<%= privateRegistry.host %>'
+<% } %>
+
 build_failed() {
   <% if (stopApp) { %>
   sudo docker start $APPNAME >/dev/null 2>&1 || true
@@ -81,14 +87,13 @@ sudo docker tag $IMAGE:latest $IMAGE:previous || true
 sudo docker tag $IMAGE:build $IMAGE:<%= tag %>
 
 <% if (privateRegistry) { %>
+  echo "Login into private registry"
+  echo $PRIVATE_REGISTRY_PASSWORD | sudo -S docker login --password-stdin --username $PRIVATE_REGISTRY_USERNAME $PRIVATE_REGISTRY_HOST
   echo "Pushing images to private registry"
   # Fails if the previous tag doesn't exist (such as during the initial deploy)
   sudo docker push $IMAGE:previous || true
-
   sudo docker push $IMAGE:latest
-  
 <% } %>
-
 echo "Tagged <%= tag %>"
 
 # Can fail if multiple Prepare Bundle apps are run concurrently for different apps


### PR DESCRIPTION
When using a private docker registry, docker commands in prepare-bundle and meteor-start scripts were not login into the private registry. Updated the code to receive the registry info from the config file and do the actual docker login when privateRegistry is set.