### PR TITLE
Update getNodeVersion call args

### DIFF
--- a/src/plugins/meteor/prepare-bundle.js
+++ b/src/plugins/meteor/prepare-bundle.js
@@ -61,7 +61,8 @@ export async function prepareBundleLocally(
     throw error;
   }
 
-  const nodeVersion = await getNodeVersion(api, buildLocation);
+  const bundlePath = api.resolvePath(buildLocation, 'bundle.tar.gz');
+  const nodeVersion = await getNodeVersion(bundlePath);
   const image = `${getImagePrefix(privateDockerRegistry)}${appConfig.name}`;
   const dockerFile = createDockerFile(appConfig);
   const dockerIgnoreContent = `


### PR DESCRIPTION
This callsite for `getNodeVersion` doesn't seem to have been updated when 1.5.2 was released.

Fixes #1240 