### PR TITLE
Custom load balance strategy

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -606,8 +606,8 @@ module.exports = {
     domains: 'website.com',
 
     loadBalancing: true,
-    // Use sticky sessions when load balancing (optional, default is true)
-    stickySessions: true,
+		// Use sticky sessions when load balancing (optional, default is true)
+		stickySessions: true,
 		// Configure the strategy used for load balancing (optional, default is 'ip_hash')
 		loadBalanceStrategy: 'least_conn'
   }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -606,10 +606,10 @@ module.exports = {
     domains: 'website.com',
 
     loadBalancing: true,
-// Use sticky sessions when load balancing (optional, default is true)
-stickySessions: true,
-// Configure the strategy used for load balancing (optional, default is 'ip_hash')
-loadBalanceStrategy: 'least_conn'
+	// Use sticky sessions when load balancing (optional, default is true)
+	stickySessions: true,
+	// Configure the strategy used for load balancing (optional, default is 'ip_hash')
+	loadBalanceStrategy: 'least_conn'
   }
 };
 ```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -607,7 +607,9 @@ module.exports = {
 
     loadBalancing: true,
     // Use sticky sessions when load balancing (optional, default is true)
-    stickySessions: true
+    stickySessions: true,
+		// Configure the strategy used for load balancing (optional, default is 'ip_hash')
+		loadBalanceStrategy: 'least_conn'
   }
 };
 ```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -606,10 +606,10 @@ module.exports = {
     domains: 'website.com',
 
     loadBalancing: true,
-		// Use sticky sessions when load balancing (optional, default is true)
-		stickySessions: true,
-		// Configure the strategy used for load balancing (optional, default is 'ip_hash')
-		loadBalanceStrategy: 'least_conn'
+	// Use sticky sessions when load balancing (optional, default is true)
+	stickySessions: true,
+	// Configure the strategy used for load balancing (optional, default is 'ip_hash')
+	loadBalanceStrategy: 'least_conn'
   }
 };
 ```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -607,9 +607,9 @@ module.exports = {
 
     loadBalancing: true,
 		// Use sticky sessions when load balancing (optional, default is true)
-stickySessions: true,
-// Configure the strategy used for load balancing (optional, default is 'ip_hash')
-loadBalanceStrategy: 'least_conn'
+		stickySessions: true,
+		// Configure the strategy used for load balancing (optional, default is 'ip_hash')
+		loadBalanceStrategy: 'least_conn'
   }
 };
 ```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -607,9 +607,9 @@ module.exports = {
 
     loadBalancing: true,
 		// Use sticky sessions when load balancing (optional, default is true)
-		stickySessions: true,
-		// Configure the strategy used for load balancing (optional, default is 'ip_hash')
-		loadBalanceStrategy: 'least_conn'
+stickySessions: true,
+// Configure the strategy used for load balancing (optional, default is 'ip_hash')
+loadBalanceStrategy: 'least_conn'
   }
 };
 ```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -606,10 +606,10 @@ module.exports = {
     domains: 'website.com',
 
     loadBalancing: true,
-	// Use sticky sessions when load balancing (optional, default is true)
-	stickySessions: true,
-	// Configure the strategy used for load balancing (optional, default is 'ip_hash')
-	loadBalanceStrategy: 'least_conn'
+// Use sticky sessions when load balancing (optional, default is true)
+stickySessions: true,
+// Configure the strategy used for load balancing (optional, default is 'ip_hash')
+loadBalanceStrategy: 'least_conn'
   }
 };
 ```

--- a/src/plugins/proxy/assets/upstream.sh
+++ b/src/plugins/proxy/assets/upstream.sh
@@ -20,7 +20,7 @@ docker exec -w /etc/nginx/vhost.d/ mup-nginx-proxy find . -xtype l -delete
 echo "Storing upstream"
 cat <<"EOT" > /opt/$PROXYNAME/upstream/$APPNAME
 <% if (stickySessions) { %>
-ip_hash;
+<%= loadBalanceStrategy %>;
 <% } %>
 <% for(var index in hostnames) { %>
 server <%= hostnames[index] %>:<%= port %>;

--- a/src/plugins/proxy/command-handlers.js
+++ b/src/plugins/proxy/command-handlers.js
@@ -156,7 +156,7 @@ export function setup(api) {
       name: appName,
       setUpstream: !api.swarmEnabled() && config.loadBalancing,
       stickySessions: config.stickySessions !== false,
-			loadBalanceStrategy: config.loadBalanceStrategy || 'ip_hash',
+      loadBalanceStrategy: config.loadBalanceStrategy || 'ip_hash',
       proxyName: PROXY_CONTAINER_NAME,
       port: appConfig.env.PORT,
       hostnames

--- a/src/plugins/proxy/command-handlers.js
+++ b/src/plugins/proxy/command-handlers.js
@@ -156,6 +156,7 @@ export function setup(api) {
       name: appName,
       setUpstream: !api.swarmEnabled() && config.loadBalancing,
       stickySessions: config.stickySessions !== false,
+			loadBalanceStrategy: config.loadBalanceStrategy || 'ip_hash',
       proxyName: PROXY_CONTAINER_NAME,
       port: appConfig.env.PORT,
       hostnames

--- a/src/plugins/proxy/validate.js
+++ b/src/plugins/proxy/validate.js
@@ -19,6 +19,7 @@ const schema = joi.object().keys({
   servers: joi.object(),
   loadBalancing: joi.bool(),
   stickySessions: joi.bool(),
+	loadBalanceStrategy: joi.string(),
   shared: joi.object().keys({
     clientUploadLimit: joi.alternatives().try(joi.number(), joi.string()),
     httpPort: joi.number(),

--- a/src/plugins/proxy/validate.js
+++ b/src/plugins/proxy/validate.js
@@ -19,7 +19,7 @@ const schema = joi.object().keys({
   servers: joi.object(),
   loadBalancing: joi.bool(),
   stickySessions: joi.bool(),
-	loadBalanceStrategy: joi.string(),
+  loadBalanceStrategy: joi.string(),
   shared: joi.object().keys({
     clientUploadLimit: joi.alternatives().try(joi.number(), joi.string()),
     httpPort: joi.number(),


### PR DESCRIPTION
Added an option to configure nginx's load balancer strategy. This option is a string to allow for custom strategies instead of just the [built in ones](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/). The configuration option is called `loadBalanceStrategy`.