### PR TITLE
bump packages version of ejs, ssh2 and shelljs from 0.8.x to 2.5.5, 0.8.9 to 1.4.0 and 0.5.3 to 0.8.5 respectively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -867,16 +867,15 @@
       }
     },
     "@zodern/nodemiral": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@zodern/nodemiral/-/nodemiral-1.3.1.tgz",
-      "integrity": "sha512-Zo1fj0ksBZt2tj941p37m8aaF6LWBQD2bCfBDtwiZrhxOg9V12xI1afbnn0+ifrO5tle4+B9KUlb5IYhX1mjRQ==",
+      "version": "git+https://github.com/myDario/nodemiral.git#9e20b7ec143b2013a8405c3fb73f6422f9b2f636",
+      "from": "git+https://github.com/myDario/nodemiral.git#9e20b7ec143b2013a8405c3fb73f6422f9b2f636",
       "requires": {
         "async": "0.9.0",
         "colors": "0.6.x",
         "debug": "^4.1.1",
-        "ejs": "0.8.x",
+        "ejs": "2.5.5",
         "progress": "^2.0.3",
-        "ssh2": "^0.8.4",
+        "ssh2": "1.4.0",
         "underscore": "^1.13.1"
       }
     },
@@ -1413,9 +1412,12 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -2587,6 +2589,15 @@
         }
       }
     },
+    "cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.1"
+      }
+    },
     "cross-env": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
@@ -2938,9 +2949,9 @@
       }
     },
     "ejs": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.8.tgz",
-      "integrity": "sha1-/9xW3MNdApJt1QrRNDm7xUBh1Zg="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
+      "integrity": "sha1-bvTpVOp9z1T2aq0v56pCGTLZ7Xc="
     },
     "electron-to-chromium": {
       "version": "1.3.453",
@@ -5306,7 +5317,6 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -7013,8 +7023,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.0",
@@ -7404,21 +7413,22 @@
       "dev": true
     },
     "ssh2": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
       "requires": {
-        "ssh2-streams": "~0.4.10"
-      }
-    },
-    "ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "requires": {
-        "asn1": "~0.2.0",
+        "asn1": "^0.2.4",
         "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+          "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+          "optional": true
+        }
       }
     },
     "state-toggle": {
@@ -7447,11 +7457,6 @@
           }
         }
       }
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-width": {
       "version": "2.1.1",
@@ -8229,9 +8234,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
     },
     "unherit": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "1.5.5",
+  "version": "1.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3694,7 +3694,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4087,6 +4086,11 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -5940,8 +5944,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -6698,6 +6701,14 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -6906,7 +6917,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
       "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -7061,9 +7071,14 @@
       "integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
     },
     "shelljs": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.1.1",
-    "@zodern/nodemiral": "^1.3.1",
+    "@zodern/nodemiral": "git+https://github.com/myDario/nodemiral.git#9e20b7ec143b2013a8405c3fb73f6422f9b2f636",
     "axios": "^0.21.4",
     "bluebird": "^3.7.2",
     "boxen": "^4.2.0",
@@ -83,7 +83,7 @@
     "rimraf": "^3.0.2",
     "shell-escape": "^0.2.0",
     "shelljs": "^0.8.5",
-    "ssh2": "^0.8.9",
+    "ssh2": "1.4.0",
     "tar": "^6.1.11",
     "traverse": "^0.6.6",
     "uuid": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.2",
     "shell-escape": "^0.2.0",
-    "shelljs": "0.5.3",
+    "shelljs": "^0.8.5",
     "ssh2": "^0.8.9",
     "tar": "^6.1.11",
     "traverse": "^0.6.6",


### PR DESCRIPTION
bump packages version of following:
ejs from 0.8.x to 2.5.5
ssh2 from 0.8.9 to 1.4.0
shelljs from 0.5.3 to 0.8.5