### PR TITLE
Fix shared Nginx config path

### DIFF
--- a/src/plugins/proxy/command-handlers.js
+++ b/src/plugins/proxy/command-handlers.js
@@ -215,7 +215,7 @@ export function reconfigShared(api) {
     }
   });
 
-  const sharedNginxConfig = shared.nginxConfig || api.resolvePath(__dirname, 'assets/proxy.conf');
+  const sharedNginxConfig = api.resolvePath(api.getBasePath(), shared.nginxConfig) || api.resolvePath(__dirname, 'assets/proxy.conf');
   list.copy('Sending nginx config', {
     src: sharedNginxConfig,
     dest: `/opt/${PROXY_CONTAINER_NAME}/config/nginx-default.conf`


### PR DESCRIPTION
Access to the shared.nginxConfig file should be provided using a relative path, similar to how it's done in the nginxServerConfig and nginxLocationConfig files. Otherwise, the full path of the file needs to be written, which can be different for each developer as you can imagine.